### PR TITLE
fix: instance inhabited instead of the use deriving

### DIFF
--- a/Specs/Config.lean
+++ b/Specs/Config.lean
@@ -6,6 +6,11 @@ structure Config where
   verbose  : Bool := false
   bail     : Bool := false
   noColors : Bool := true
-  deriving Inhabited
+
+instance : Inhabited Config := ⟨{
+  verbose  := false
+  bail     := false
+  noColors := true
+}⟩
 
 end Specs


### PR DESCRIPTION
We need the default configuration to have some flags disabled by default.

I noticed this, when I was using the `#test` macro and it was showing the ANSI colors, here is an example of this bug:

<img width="668" alt="image" src="https://github.com/axiomed/Specs.lean/assets/44513615/211472d1-e536-43f1-9007-7196008c61ea">
